### PR TITLE
Reminders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = "0.4"
 futures = "0.3"
 serde_json = "1.0"
 slack = "0.25"

--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -91,7 +91,7 @@ where
     }
 }
 
-fn read_agenda() -> Agenda {
+pub fn read_agenda() -> Agenda {
     serde_json::from_str::<Agenda>(
         &fs::read_to_string("agenda.json").expect("Can't read agenda.json"),
     )

--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -35,6 +35,21 @@ impl Agenda {
     }
 }
 
+impl fmt::Display for Agenda {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = self
+            .points
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        write!(f, "{}", match s.as_str() {
+            "" => "Empty agenda",
+            _ => &s
+        })
+    }
+}
+
 pub enum Emoji {
     Ok,
     Confused,
@@ -61,16 +76,7 @@ where
         agenda.write();
         Some(Emoji::Ok)
     } else if message.starts_with("!agenda") {
-        let s = read_agenda()
-            .points
-            .iter()
-            .map(|p| p.to_string())
-            .collect::<Vec<_>>()
-            .join("\n");
-        send_message(match s.as_str() {
-            "" => "Agenda is empty".to_string(),
-            _ => s,
-        });
+        send_message(read_agenda().to_string());
         None
     } else if message.starts_with("!clear") {
         Agenda { points: Vec::new() }.write();

--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -43,10 +43,14 @@ impl fmt::Display for Agenda {
             .map(|p| p.to_string())
             .collect::<Vec<_>>()
             .join("\n");
-        write!(f, "{}", match s.as_str() {
-            "" => "Empty agenda",
-            _ => &s
-        })
+        write!(
+            f,
+            "{}",
+            match s.as_str() {
+                "" => "Empty agenda",
+                _ => &s,
+            }
+        )
     }
 }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,4 +1,4 @@
-use crate::agenda::{parse_message, AgendaPoint, Emoji};
+use crate::agenda::{self, parse_message, AgendaPoint, Emoji};
 
 use discord::{
     model::{ChannelId, Event, PossibleServer, ReactionEmoji, UserId},

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -175,13 +175,17 @@ async fn handle_reminders(
                     client
                         .lock()
                         .unwrap()
-                        .send_message(channel,
-                                      &format!("Meeting in one hour!\n{}",
-                                              agenda::read_agenda().to_string()),
-                                      "",
-                                      false)
+                        .send_message(
+                            channel,
+                            &format!(
+                                "Meeting in one hour!\n{}",
+                                agenda::read_agenda().to_string()
+                            ),
+                            "",
+                            false,
+                        )
                         .unwrap();
-                },
+                }
                 ReminderType::Void => {}
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod agenda;
 mod discord;
+mod reminder;
 mod slack;
 
 use crate::agenda::AgendaPoint;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,20 @@ mod reminder;
 mod slack;
 
 use crate::agenda::AgendaPoint;
+use crate::reminder::ReminderType;
 use futures::join;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 #[tokio::main]
 async fn main() {
-    println!("Hello, world!");
-
     let (from_discord, to_slack) = mpsc::unbounded_channel::<AgendaPoint>();
     let (from_slack, to_discord) = mpsc::unbounded_channel::<AgendaPoint>();
 
+    let (reminder_sender, reminder_receiver) = watch::channel(ReminderType::Void);
+
     join!(
-        discord::handle(from_discord, to_discord),
-        slack::handle(from_slack, to_slack),
+        reminder::handle(reminder_sender),
+        discord::handle(from_discord, to_discord, reminder_receiver.clone()),
+        slack::handle(from_slack, to_slack, reminder_receiver),
     );
 }

--- a/src/reminder.rs
+++ b/src/reminder.rs
@@ -8,7 +8,7 @@ pub enum ReminderType {
     // Different types of reminders are possible.
     // e.g. different reminders for the day before and one hour before.
     Void,
-    OneHour,  //TODO struct instead
+    OneHour, //TODO struct instead
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -45,8 +45,8 @@ pub async fn handle(sender: watch::Sender<ReminderType>) {
                     sender.broadcast(ReminderType::OneHour).unwrap();
                     reminder.last_fire = now;
                 }
-            },
-            _ => {},
+            }
+            _ => {}
         }
     }
     reminders.write();
@@ -57,10 +57,8 @@ pub async fn handle(sender: watch::Sender<ReminderType>) {
 }
 
 fn read_reminders() -> Reminders {
-    serde_json::from_str(
-        &fs::read_to_string("reminders.json").expect("Can't read reminders.json")
-    )
-    .expect("Error parsing reminders.json")
+    serde_json::from_str(&fs::read_to_string("reminders.json").expect("Can't read reminders.json"))
+        .expect("Error parsing reminders.json")
 }
 
 fn in_remind_zone(dt: DateTime<Local>, meeting: DateTime<Local>) -> bool {
@@ -77,16 +75,14 @@ fn next_meeting() -> DateTime<Local> {
         Weekday::Thu => {
             // same day as meeting.
             // next week if meeting has occured.
-            let date_delta = Duration::weeks(
-                if now.time() < meeting_time { 0 } else { 1 }
-            );
+            let date_delta = Duration::weeks(if now.time() < meeting_time { 0 } else { 1 });
             (now.date() + date_delta).and_time(meeting_time).unwrap()
-        },
+        }
         _ => {
             let dow_index: i64 = now.date().weekday().num_days_from_monday().into();
             let date_delta = Duration::days((3 - dow_index).rem_euclid(7));
             (now.date() + date_delta).and_time(meeting_time).unwrap()
-        },
+        }
     };
     assert!(meeting.weekday() == Weekday::Thu);
     meeting

--- a/src/reminder.rs
+++ b/src/reminder.rs
@@ -57,8 +57,13 @@ pub async fn handle(sender: watch::Sender<ReminderType>) {
 }
 
 fn read_reminders() -> Reminders {
-    serde_json::from_str(&fs::read_to_string("reminders.json").expect("Can't read reminders.json"))
-        .expect("Error parsing reminders.json")
+    match fs::read_to_string("reminders.json") {
+        Ok(s) => serde_json::from_str(&s).expect("Error parsing reminders.json"),
+        Err(_) => Reminders { reminders: vec![Reminder {
+            reminder_type: ReminderType::OneHour,
+            last_fire: Local::now(),
+        }]},
+    }
 }
 
 fn in_remind_zone(dt: DateTime<Local>, meeting: DateTime<Local>) -> bool {

--- a/src/reminder.rs
+++ b/src/reminder.rs
@@ -1,0 +1,106 @@
+use chrono::{DateTime, Datelike, Duration, Local, NaiveTime, Weekday};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use tokio::sync::watch;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ReminderType {
+    // Different types of reminders are possible.
+    // e.g. different reminders for the day before and one hour before.
+    Void,
+    OneHour,  //TODO struct instead
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Reminder {
+    reminder_type: ReminderType,
+    last_fire: DateTime<Local>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Reminders {
+    reminders: Vec<Reminder>,
+}
+
+impl Reminders {
+    fn write(&self) {
+        fs::write(
+            std::path::Path::new("reminders.json"),
+            serde_json::to_string_pretty(&self).expect("Can't serialize reminders"),
+        )
+        .expect("Can't write reminders.json")
+    }
+}
+
+pub async fn handle(sender: watch::Sender<ReminderType>) {
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(1000));
+
+    let now = Local::now();
+    let next = next_meeting();
+    let mut reminders = read_reminders();
+    for mut reminder in &mut reminders.reminders {
+        match reminder.reminder_type {
+            ReminderType::OneHour => {
+                if in_remind_zone(now, next) && !in_remind_zone(reminder.last_fire, next) {
+                    sender.broadcast(ReminderType::OneHour).unwrap();
+                    reminder.last_fire = now;
+                }
+            },
+            _ => {},
+        }
+    }
+    reminders.write();
+
+    loop {
+        interval.tick().await;
+    }
+}
+
+fn read_reminders() -> Reminders {
+    serde_json::from_str(
+        &fs::read_to_string("reminders.json").expect("Can't read reminders.json")
+    )
+    .expect("Error parsing reminders.json")
+}
+
+fn in_remind_zone(dt: DateTime<Local>, meeting: DateTime<Local>) -> bool {
+    // Wether we're in a "send reminder"-zone.
+    // Currently implemented as "are we 1 hour before?".
+    ((meeting - Duration::hours(1))..meeting).contains(&dt)
+}
+
+fn next_meeting() -> DateTime<Local> {
+    // Check current datetime and calculate when the next meeting is.
+    let now = Local::now();
+    let meeting_time = NaiveTime::from_hms(12, 15, 00);
+    let meeting = match Datelike::weekday(&now) {
+        Weekday::Thu => {
+            // same day as meeting.
+            // next week if meeting has occured.
+            let date_delta = Duration::weeks(
+                if now.time() < meeting_time { 0 } else { 1 }
+            );
+            (now.date() + date_delta).and_time(meeting_time).unwrap()
+        },
+        _ => {
+            let dow_index: i64 = now.date().weekday().num_days_from_monday().into();
+            let date_delta = Duration::days((3 - dow_index).rem_euclid(7));
+            (now.date() + date_delta).and_time(meeting_time).unwrap()
+        },
+    };
+    assert!(meeting.weekday() == Weekday::Thu);
+    meeting
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_remind_zone() {
+        let now = Local::now();
+        assert!(super::in_remind_zone(now, now + Duration::minutes(30)));
+        assert!(!super::in_remind_zone(now, now + Duration::hours(2)));
+        assert!(!super::in_remind_zone(now, now - Duration::minutes(30)));
+    }
+}

--- a/src/reminder.rs
+++ b/src/reminder.rs
@@ -35,23 +35,22 @@ impl Reminders {
 pub async fn handle(sender: watch::Sender<ReminderType>) {
     let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(1000));
 
-    let now = Local::now();
-    let next = next_meeting();
-    let mut reminders = read_reminders();
-    for mut reminder in &mut reminders.reminders {
-        match reminder.reminder_type {
-            ReminderType::OneHour => {
-                if in_remind_zone(now, next) && !in_remind_zone(reminder.last_fire, next) {
-                    sender.broadcast(ReminderType::OneHour).unwrap();
-                    reminder.last_fire = now;
-                }
-            }
-            _ => {}
-        }
-    }
-    reminders.write();
-
     loop {
+        let now = Local::now();
+        let next = next_meeting();
+        let mut reminders = read_reminders();
+        for mut reminder in &mut reminders.reminders {
+            match reminder.reminder_type {
+                ReminderType::OneHour => {
+                    if in_remind_zone(now, next) && !in_remind_zone(reminder.last_fire, next) {
+                        sender.broadcast(ReminderType::OneHour).unwrap();
+                        reminder.last_fire = now;
+                    }
+                }
+                _ => {}
+            }
+        }
+        reminders.write();
         interval.tick().await;
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -138,7 +138,7 @@ impl slack::EventHandler for Handler {
                                                         timestamp: Some(msg.ts.unwrap()),
                                                     },
                                                 )
-                                                    .compat(),
+                                                .compat(),
                                             )
                                             .unwrap();
                                     }
@@ -189,7 +189,11 @@ pub async fn handle(
     let slack_sender = client.sender().clone();
 
     let (_, _, _) = join!(
-        spawn(receive_from_discord(receiver, slack_sender.clone(), channel.clone())),
+        spawn(receive_from_discord(
+            receiver,
+            slack_sender.clone(),
+            channel.clone()
+        )),
         spawn(handle_reminders(reminder, slack_sender, channel)),
         spawn_blocking(move || {
             match client.run(&mut handler) {
@@ -229,9 +233,12 @@ async fn handle_reminders(
                 ReminderType::OneHour => {
                     sender.send_typing(&channel).unwrap();
                     sender
-                        .send_message(&channel, &format!("Meeting in one hour!\n{}", agenda::read_agenda()))
+                        .send_message(
+                            &channel,
+                            &format!("Meeting in one hour!\n{}", agenda::read_agenda()),
+                        )
                         .unwrap();
-                },
+                }
                 ReminderType::Void => {}
             }
         }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,4 +1,4 @@
-use crate::agenda::{parse_message, AgendaPoint, Emoji};
+use crate::agenda::{self, parse_message, AgendaPoint, Emoji};
 
 use futures::join;
 use slack::{Event, Message};


### PR DESCRIPTION
Reminders are sent one hour before the meeting starts.

TODO:
- [ ] One hour before: tag board and print agenda.
- [ ] Fifteen minutes before: print agenda.
- [ ] Store reminder-data in memory, only read when a reminder has been sent and we receive a reload command.

Future work:

- Choose when reminders should be printed
- Skip meetings
- Multiple `ReminderType`s

Closes #14 